### PR TITLE
Perform signature checks for all basic blocks except the entry block.

### DIFF
--- a/lib/CFCSS/InstrumentBasicBlocks.cpp
+++ b/lib/CFCSS/InstrumentBasicBlocks.cpp
@@ -241,6 +241,12 @@ namespace cfcss {
       bool adjustForFanin,
       Instruction *insertBefore) {
 
+    assert(BB);
+    assert(errorHandlingBlock);
+    assert(signature);
+    assert(predecessorSignature);
+    assert(insertBefore);
+
     DEBUG(errs() << debugPrefix << "Instrumenting [" << BB->getName() << "]\n");
 
     // Compute the signature update.

--- a/lib/CFCSS/InstrumentBasicBlocks.cpp
+++ b/lib/CFCSS/InstrumentBasicBlocks.cpp
@@ -99,7 +99,16 @@ namespace cfcss {
               i->getFirstNonPHI());
 
         } else {
-          // TODO(hermannloose): Implement signature checks for normal blocks.
+          BasicBlock *authoritativePredecessor = ABS->getAuthoritativePredecessor(i);
+          assert(authoritativePredecessor);
+
+          insertSignatureUpdate(
+              i,
+              errorHandlingBlock,
+              ABS->getSignature(i),
+              ABS->getSignature(authoritativePredecessor),
+              ABS->isFaninNode(i), /* adjustForFanin */
+              i->getFirstNonPHI());
         }
 
         // TODO(hermannloose): Put this towards the end of block processing.


### PR DESCRIPTION
This fixes #12.
