### PR TITLE
Change gateway construction to allow ignoring function pointers for now.

### DIFF
--- a/lib/CFCSS/InstrumentBasicBlocks.cpp
+++ b/lib/CFCSS/InstrumentBasicBlocks.cpp
@@ -105,6 +105,15 @@ namespace cfcss {
 
       BasicBlock *errorHandlingBlock = createErrorHandlingBlock(fi);
 
+      // All instrumented functions store at least once to the global interFunctionGSR, yet they
+      // might have previously been annotated as read-only or read-none.
+      AttributeSet attributes = fi->getAttributes();
+      attributes = attributes.removeAttribute(
+          getGlobalContext(), AttributeSet::FunctionIndex, Attribute::ReadNone);
+      attributes = attributes.removeAttribute(
+          getGlobalContext(), AttributeSet::FunctionIndex, Attribute::ReadOnly);
+      fi->setAttributes(attributes);
+
       DEBUG(errs() << debugPrefix << "Instrumenting entry block.\n");
 
       // TODO(hermannloose): Maybe delegate to two functions for this.


### PR DESCRIPTION
This addresses the issue I [mentioned](https://github.com/hermannloose/cfcss/issues/24#issuecomment-26333105) in #24.

Additionally any existing `readnone` or `readonly` attributes are removed from all instrumented functions, since they all contain at least one `store` to the global `interFunctionGSR`. Dead code elimination after instrumentation could previously remove calls to instrumented functions, resulting in signature mismatch. (no bug filed)
